### PR TITLE
Add shared Daggerheart type definitions

### DIFF
--- a/src/types/daggerheart.ts
+++ b/src/types/daggerheart.ts
@@ -1,0 +1,35 @@
+export type Trait =
+  | 'Agility'
+  | 'Strength'
+  | 'Finesse'
+  | 'Instinct'
+  | 'Presence'
+  | 'Knowledge'
+
+export interface ClassOption {
+  id: string
+  name: string
+  description?: string
+}
+
+export interface HeritageOption {
+  id: string
+  name: string
+  description?: string
+}
+
+export interface DomainCard {
+  id: string
+  name: string
+  description?: string
+}
+
+export interface Character {
+  traits: Record<Trait, number>
+  name?: string
+  pronouns?: string
+  classOption?: ClassOption
+  heritageOption?: HeritageOption
+  domainCards?: DomainCard[]
+  level?: number
+}


### PR DESCRIPTION
## Summary
- create `Trait` union type
- add interfaces for `Character`, `ClassOption`, `HeritageOption`, and `DomainCard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.app.json` *(fails: Cannot find module 'react')*