### PR TITLE
Fix blank pages by switching to HashRouter

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- use `HashRouter` instead of `BrowserRouter`

## Testing
- `npm run build` *(fails: Cannot find module '@vitejs/plugin-react')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683b75c36e7c83238760f3ce330bbaab