### PR TITLE
Implement dynamic backstory questions

### DIFF
--- a/src/pages/steps/Step1_Class.tsx
+++ b/src/pages/steps/Step1_Class.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import * as Icons from 'lucide-react'
 import classesData from '../../../data/classes.json'
 import { useCharacter } from '../../store/useCharacter'
+import { useSheetStore } from '../../stores/sheet'
 
 type ClassItem = {
   id: string
@@ -31,9 +32,11 @@ const classes: ClassItem[] = (classesData as ClassData[]).map((cls) => ({
 export default function Step1_Class() {
   const [open, setOpen] = useState<string | null>(null)
   const { class: selectedClass, subclass, setClass } = useCharacter()
+  const updateSheet = useSheetStore((s) => s.updateSheet)
 
   const handleSelect = (cls: ClassItem, sub: string) => {
     setClass(cls.id, sub)
+    updateSheet({ classId: cls.id })
   }
 
   return (

--- a/src/pages/steps/Step8_Backstory.tsx
+++ b/src/pages/steps/Step8_Backstory.tsx
@@ -1,17 +1,61 @@
-import { useCharacterStore } from '../../stores/useCharacterStore'
+import { useState, useEffect } from 'react'
+import classes from '@/data/classes.json'
+import { useSheetStore, BackgroundAnswers } from '../../stores/sheet'
 
 export default function Step8_Backstory() {
-  const backstory = useCharacterStore((state) => state.backstory)
-  const setBackstory = useCharacterStore((state) => state.setBackstory)
+  const { sheet, updateSheet } = useSheetStore((s) => ({
+    sheet: s.sheet,
+    updateSheet: s.updateSheet,
+  }))
+
+  const [answers, setAnswers] = useState<BackgroundAnswers>(
+    sheet.background.answers ?? {}
+  )
+  const [notes, setNotes] = useState(sheet.background.notes)
+
+  const currentClass = classes.find((c) => c.id === sheet.classId)
+
+  const questions = currentClass
+    ? [
+        `Why did you choose the path of a ${currentClass.name}?`,
+        `Which personal item do you treasure?  (e.g., ${currentClass.classItems})`,
+        `What fear or hope drives your ${currentClass.name}?`,
+      ]
+    : []
+
+  const handleAnswerChange = (key: string, value: string) => {
+    setAnswers((prev) => ({ ...prev, [key]: value }))
+  }
+
+  useEffect(() => {
+    updateSheet({ background: { answers, notes } })
+  }, [answers, notes, updateSheet])
 
   return (
-    <div>
-      <h2>Step 8: Backstory</h2>
-      <input
-        value={backstory}
-        onChange={(e) => setBackstory(e.target.value)}
-        placeholder="Write a backstory"
-      />
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-bold">Step 8: Backstory</h2>
+      {questions.map((q, idx) => (
+        <label key={idx} className="block space-y-1">
+          <span>{q}</span>
+          <textarea
+            className="w-full border rounded p-2"
+            value={answers[String(idx)] ?? ''}
+            onChange={(e) => handleAnswerChange(String(idx), e.target.value)}
+          />
+        </label>
+      ))}
+      <label className="block space-y-1">
+        <span>Free-form notes</span>
+        <textarea
+          className="w-full border rounded p-2"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+        />
+      </label>
+      <div className="flex justify-between">
+        <button className="px-4 py-2 border rounded">Back</button>
+        <button className="px-4 py-2 border rounded">Next</button>
+      </div>
     </div>
   )
 }

--- a/src/stores/sheet.ts
+++ b/src/stores/sheet.ts
@@ -1,0 +1,33 @@
+import { create } from 'zustand'
+
+export type BackgroundAnswers = Record<string, string>
+
+export interface BackgroundState {
+  answers: BackgroundAnswers
+  notes: string
+}
+
+export interface SheetState {
+  classId: string | null
+  background: BackgroundState
+}
+
+interface Store {
+  sheet: SheetState
+  updateSheet: (patch: Partial<SheetState>) => void
+}
+
+export const useSheetStore = create<Store>((set) => ({
+  sheet: { classId: null, background: { answers: {}, notes: '' } },
+  updateSheet: (patch) =>
+    set((state) => ({
+      sheet: {
+        ...state.sheet,
+        ...patch,
+        background: {
+          ...state.sheet.background,
+          ...(patch.background ?? {}),
+        },
+      },
+    })),
+}))


### PR DESCRIPTION
## Summary
- add zustand sheet store to hold chosen class and backstory info
- record chosen class in Step1 selection
- generate Step8 questions from the chosen class and save answers

## Testing
- `npm run build` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_683b7d854fd8832394e9b464740f0bc6