### PR TITLE
Add experiences step

### DIFF
--- a/data/experienceBlacklist.json
+++ b/data/experienceBlacklist.json
@@ -1,0 +1,6 @@
+[
+  "combat",
+  "magic",
+  "stealth",
+  "adventure"
+]

--- a/src/pages/steps/ExperiencesStep.tsx
+++ b/src/pages/steps/ExperiencesStep.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import badExp from '../../../data/experienceBlacklist.json'
+import { useCharacterStore } from '../../stores/useCharacterStore'
+
+function isNonEmpty(value: string) {
+  return value.trim().length > 0
+}
+
+function isUnder30Chars(value: string) {
+  return value.length <= 30
+}
+
+function isDistinct(list: string[]) {
+  return new Set(list.map((s) => s.trim().toLowerCase())).size === list.length
+}
+
+function isNotTooBroad(value: string) {
+  return !badExp.includes(value.trim().toLowerCase())
+}
+
+export default function ExperiencesStep() {
+  const stored = useCharacterStore((s) => s.experiences)
+  const save = useCharacterStore((s) => s.setExperiences)
+
+  const [experiences, setExperiences] = useState<string[]>(stored || ['', ''])
+
+  const update = (idx: number, value: string) => {
+    const next = [...experiences]
+    next[idx] = value
+    setExperiences(next)
+  }
+
+  const validations = experiences.map((exp) => ({
+    isNonEmpty: isNonEmpty(exp),
+    isUnder30Chars: isUnder30Chars(exp),
+    isNotTooBroad: isNotTooBroad(exp),
+  }))
+  const distinct = isDistinct(experiences)
+  const allValid =
+    distinct && validations.every((v) => v.isNonEmpty && v.isUnder30Chars && v.isNotTooBroad)
+
+  useEffect(() => {
+    if (allValid) save(experiences)
+  }, [allValid, experiences, save])
+
+  return (
+    <div>
+      <h2>Choose Experiences</h2>
+      {experiences.map((exp, idx) => {
+        const val = validations[idx]
+        return (
+          <div key={idx} className="mb-4">
+            <input
+              value={exp}
+              onChange={(e) => update(idx, e.target.value)}
+              className="border p-1"
+            />
+            {!val.isNonEmpty && <p className="text-red-500 text-sm">Required</p>}
+            {!val.isUnder30Chars && (
+              <p className="text-red-500 text-sm">Must be 30 characters or less</p>
+            )}
+            {!val.isNotTooBroad && (
+              <p className="text-red-500 text-sm">Too broad, choose something more specific</p>
+            )}
+            {!distinct && <p className="text-red-500 text-sm">Experiences must be unique</p>}
+          </div>
+        )
+      })}
+      <div className="flex gap-2 justify-end">
+        <button className="px-4 py-2 border rounded">Back</button>
+        <button
+          className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+          disabled={!allValid}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/stores/useCharacterStore.ts
+++ b/src/stores/useCharacterStore.ts
@@ -10,6 +10,7 @@ interface CharacterState {
   equipment: string
   backstory: string
   connections: string
+  experiences: string[]
   setCharacterClass: (value: string) => void
   setHeritage: (value: string) => void
   setCulture: (value: string) => void
@@ -19,6 +20,7 @@ interface CharacterState {
   setEquipment: (value: string) => void
   setBackstory: (value: string) => void
   setConnections: (value: string) => void
+  setExperiences: (value: string[]) => void
 }
 
 export const useCharacterStore = create<CharacterState>((set) => ({
@@ -31,6 +33,7 @@ export const useCharacterStore = create<CharacterState>((set) => ({
   equipment: '',
   backstory: '',
   connections: '',
+  experiences: ['', ''],
   setCharacterClass: (value) => set({ characterClass: value }),
   setHeritage: (value) => set({ heritage: value }),
   setCulture: (value) => set({ culture: value }),
@@ -40,4 +43,5 @@ export const useCharacterStore = create<CharacterState>((set) => ({
   setEquipment: (value) => set({ equipment: value }),
   setBackstory: (value) => set({ backstory: value }),
   setConnections: (value) => set({ connections: value }),
+  setExperiences: (value) => set({ experiences: value }),
 }))


### PR DESCRIPTION
## Summary
- store experiences in the character store
- validate against new `experienceBlacklist.json`
- add `ExperiencesStep` component for entering two experience tags

## Testing
- `npx vitest run` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683b7d9766d48323bd29f41055703898