### PR TITLE
Add domain card selection step

### DIFF
--- a/data/domainCards.json
+++ b/data/domainCards.json
@@ -1,0 +1,20 @@
+[
+  {"id":"arcana_blast","domainId":"arcana","level":1,"name":"Arcane Blast","description":"Unleash a surge of raw arcane power.","cost":1},
+  {"id":"arcana_aid","domainId":"arcana","level":1,"name":"Mystic Aid","description":"Bolster an ally with magical energy.","cost":1},
+  {"id":"blade_strike","domainId":"blade","level":1,"name":"Steel Strike","description":"Strike with lethal precision.","cost":1},
+  {"id":"blade_guard","domainId":"blade","level":1,"name":"Guard Stance","description":"Ready your blade to deflect attacks.","cost":1},
+  {"id":"bone_focus","domainId":"bone","level":1,"name":"Bone Focus","description":"Center yourself for the coming fight.","cost":1},
+  {"id":"bone_resilience","domainId":"bone","level":1,"name":"Resilience","description":"Endure pain through sheer grit.","cost":1},
+  {"id":"codex_bind","domainId":"codex","level":1,"name":"Bind Rune","description":"Restrict a foe with arcane formulae.","cost":1},
+  {"id":"codex_ward","domainId":"codex","level":1,"name":"Ward","description":"Protect an area with scripted magic.","cost":1},
+  {"id":"grace_charm","domainId":"grace","level":1,"name":"Charming Presence","description":"Disarm tension with a quick smile.","cost":1},
+  {"id":"grace_illusion","domainId":"grace","level":1,"name":"Minor Illusion","description":"Conjure a brief and harmless trick.","cost":1},
+  {"id":"midnight_shroud","domainId":"midnight","level":1,"name":"Shroud","description":"Wrap yourself in concealing shadow.","cost":1},
+  {"id":"midnight_step","domainId":"midnight","level":1,"name":"Shadow Step","description":"Slip briefly between the darkness.","cost":1},
+  {"id":"sage_grow","domainId":"sage","level":1,"name":"Rapid Growth","description":"Entangle foes with sudden vines.","cost":1},
+  {"id":"sage_wild","domainId":"sage","level":1,"name":"Wild Insight","description":"Listen to the whispers of nature.","cost":1},
+  {"id":"splendor_heal","domainId":"splendor","level":1,"name":"Healing Light","description":"Mend wounds with radiant power.","cost":1},
+  {"id":"splendor_radiance","domainId":"splendor","level":1,"name":"Radiant Burst","description":"Dazzle enemies with holy light.","cost":1},
+  {"id":"valor_shield","domainId":"valor","level":1,"name":"Valor Shield","description":"Interpose a barrier for an ally.","cost":1},
+  {"id":"valor_inspire","domainId":"valor","level":1,"name":"Inspiring Cry","description":"Rally companions to greater deeds.","cost":1}
+]

--- a/src/components/DomainCard.tsx
+++ b/src/components/DomainCard.tsx
@@ -1,0 +1,30 @@
+import { forwardRef } from 'react'
+
+export interface DomainCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  name: string
+  description: string
+  cost: number
+  selected?: boolean
+}
+
+const DomainCard = forwardRef<HTMLDivElement, DomainCardProps>(
+  (
+    { name, description, cost, selected, className = '', ...rest },
+    ref,
+  ) => {
+    const base = 'rounded border p-4 cursor-pointer flex flex-col gap-1 transition-colors'
+    const active = 'bg-blue-50 border-blue-500'
+    const inactive = 'border-gray-300'
+    const classes = `${base} ${selected ? active : inactive} ${className}`
+    return (
+      <div ref={ref} className={classes} {...rest}>
+        <div className="font-semibold">{name}</div>
+        <p className="text-sm">{description}</p>
+        <div className="text-xs mt-1">Cost: {cost}</div>
+      </div>
+    )
+  },
+)
+
+DomainCard.displayName = 'DomainCard'
+export default DomainCard

--- a/src/pages/steps/DomainsStep.tsx
+++ b/src/pages/steps/DomainsStep.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react'
+import classesData from '../../../data/classes.json'
+import domainsData from '../../../data/domains.json'
+import domainCardsData from '../../../data/domainCards.json'
+import { useCharacter } from '../../store/useCharacter'
+import DomainCard from '../../components/DomainCard'
+
+interface ClassEntry {
+  id: string
+  domains: string[]
+}
+
+interface Domain {
+  id: string
+  name: string
+}
+
+interface DomainCardData {
+  id: string
+  domainId: string
+  level: number
+  name: string
+  description: string
+  cost: number
+}
+
+export default function DomainsStep() {
+  const { sheet, updateSheet } = useCharacter()
+  const cls = (classesData as ClassEntry[]).find((c) => c.id === sheet.classId)
+  const allowedDomainIds = cls ? cls.domains.map((d) => d.toLowerCase()) : []
+
+  const level1Cards = (domainCardsData as DomainCardData[]).filter(
+    (c) => allowedDomainIds.includes(c.domainId) && c.level === 1,
+  )
+
+  const cardsByDomain = level1Cards.reduce<Record<string, DomainCardData[]>>( (
+    acc,
+    card,
+  ) => {
+    if (!acc[card.domainId]) acc[card.domainId] = []
+    acc[card.domainId].push(card)
+    return acc
+  }, {})
+
+  const [chosen, setChosen] = useState<string[]>(sheet.domainCards)
+
+  const toggle = (id: string) => {
+    setChosen((prev) => {
+      let next: string[]
+      if (prev.includes(id)) {
+        next = prev.filter((c) => c !== id)
+      } else if (prev.length >= 2) {
+        next = [...prev.slice(1), id]
+      } else {
+        next = [...prev, id]
+      }
+      updateSheet({ domainCards: next })
+      return next
+    })
+  }
+
+  const picked = chosen.length
+
+  return (
+    <div className="space-y-4">
+      <div className="text-right font-semibold">Picked {picked} / 2</div>
+      {Object.entries(cardsByDomain).map(([domainId, cards]) => {
+        const domain = (domainsData as Domain[]).find((d) => d.id === domainId)
+        return (
+          <div key={domainId} className="space-y-2">
+            <h3 className="font-bold">{domain?.name}</h3>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+              {cards.map((card) => (
+                <DomainCard
+                  key={card.id}
+                  name={card.name}
+                  description={card.description}
+                  cost={card.cost}
+                  selected={chosen.includes(card.id)}
+                  onClick={() => toggle(card.id)}
+                />
+              ))}
+            </div>
+          </div>
+        )
+      })}
+      <div className="flex justify-between pt-4">
+        <button className="px-4 py-2 border rounded">Back</button>
+        <button
+          className="px-4 py-2 border rounded bg-indigo-600 text-white disabled:opacity-50"
+          disabled={picked !== 2}
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/store/useCharacter.ts
+++ b/src/store/useCharacter.ts
@@ -1,14 +1,33 @@
 import { create } from 'zustand'
 
+export interface Sheet {
+  classId: string | null
+  subclassId: string | null
+  domainCards: string[]
+}
+
 interface CharacterState {
   class?: string
   subclass?: string
+  sheet: Sheet
   setClass: (className: string, subclassName: string) => void
+  updateSheet: (changes: Partial<Sheet>) => void
 }
 
 export const useCharacter = create<CharacterState>((set) => ({
   class: undefined,
   subclass: undefined,
+  sheet: { classId: null, subclassId: null, domainCards: [] },
   setClass: (className, subclassName) =>
-    set({ class: className, subclass: subclassName }),
+    set((state) => ({
+      class: className,
+      subclass: subclassName,
+      sheet: {
+        ...state.sheet,
+        classId: className,
+        subclassId: subclassName,
+      },
+    })),
+  updateSheet: (changes) =>
+    set((state) => ({ sheet: { ...state.sheet, ...changes } })),
 }))


### PR DESCRIPTION
## Summary
- add domain card data with level 1 examples
- expand character store to expose `sheet` and `updateSheet`
- create a reusable `DomainCard` component
- implement `DomainsStep` for picking two domain cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find module 'react-router-dom' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683b7e0a68788323b75de54861ee5f80