### PR TITLE
Fix Step2 heritage data types

### DIFF
--- a/src/pages/steps/Step2_Heritage.tsx
+++ b/src/pages/steps/Step2_Heritage.tsx
@@ -6,14 +6,21 @@ import { useStore } from '../../store'
 type Ancestry = {
   id: string
   name: string
-  topFeature: string
-  bottomFeature: string
+  description: string
+  features: {
+    name: string
+    description: string
+  }[]
 }
 
 type Community = {
   id: string
   name: string
-  feature: string
+  adjectives: string[]
+  feature: {
+    name: string
+    description: string
+  }
 }
 
 export default function Step2_Heritage() {
@@ -40,11 +47,13 @@ export default function Step2_Heritage() {
   const getAncestry = (id: string | null) =>
     (ancestries as Ancestry[]).find((a) => a.id === id)
 
-  const topFeature = getAncestry(primary)?.topFeature
+  const topFeature = getAncestry(primary)?.features[0]?.name
   const bottomFeature = mixed
-    ? getAncestry(secondary)?.bottomFeature
-    : getAncestry(primary)?.bottomFeature
-  const communityFeature = (communities as Community[]).find((c) => c.id === community)?.feature
+    ? getAncestry(secondary)?.features[1]?.name
+    : getAncestry(primary)?.features[1]?.name
+  const communityFeature = (
+    communities as Community[]
+  ).find((c) => c.id === community)?.feature.name
 
   const disabledNext = !primary || !community || (mixed && !secondary)
 


### PR DESCRIPTION
## Summary
- correct `Ancestry` and `Community` type definitions
- use data from JSON to show top/bottom ancestry features and community feature

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683b7ee1a6288323b8e9cf9e3b39361c